### PR TITLE
Change link from `https://etcher.download` to avoid uBlock warnings about malware

### DIFF
--- a/site/content/docs/getting-started.md
+++ b/site/content/docs/getting-started.md
@@ -28,7 +28,9 @@ If the download is correct the hash will be the same.
 ## 2.Flash your USB drive
 
 To write an ISO there are different tools and ways. My suggestion is to use the wonderful tool
-[Balena Etcher](https://etcher.download/) that validates the written bytes before sharing the result.
+[Balena Etcher](https://etcher.balena.io/)
+([Github](https://github.com/balena-io/etcher/releases)) that validates the
+written bytes before sharing the result.
 
 **NOTE**: At the moment the `ventoy` USB Solution is not supported.
 


### PR DESCRIPTION
In the Getting Started page, there was a link to https://etcher.download that was getting incorrectly flagged as a malware risk by uBlock Origin.  The links on that page were legitimate; but there have apparently been instances of miscreants having created fake lookalike software to do nefarious things to people who used it.  New link goes to https://etcher.balena.io, with a second to the Github releases page.